### PR TITLE
Fix WorldMap import and missing dependency

### DIFF
--- a/blabla/package.json
+++ b/blabla/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "15.3.4",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-simple-maps": "^3.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/blabla/src/app/page.tsx
+++ b/blabla/src/app/page.tsx
@@ -1,4 +1,4 @@
-import WorldMap from "@/components/WorldMap";
+import WorldMap from "./components/WorldMap";
 
 export default function Home() {
   const handleCountryClick = (country: any) => {


### PR DESCRIPTION
## Summary
- fix path to `WorldMap` component
- include `react-simple-maps` dependency so the world map renders correctly

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603f1429688329bf1d152568d3c3c5