### PR TITLE
Add world map panel and projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Saaftris
+
+Ce projet contient le code de mon site personnel construit avec Next.js et Tailwind CSS.
+
+## Démarrage
+
+```bash
+cd blabla
+npm install
+npm run dev
+```
+
+Le site est accessible sur `http://localhost:3000`.

--- a/blabla/package-lock.json
+++ b/blabla/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "15.3.4",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-simple-maps": "^3.0.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",

--- a/blabla/package.json
+++ b/blabla/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "15.3.4",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-simple-maps": "^3.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/blabla/src/app/components/CountryPanel.tsx
+++ b/blabla/src/app/components/CountryPanel.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+interface CountryPanelProps {
+  countryName: string;
+  onClose: () => void;
+}
+
+export default function CountryPanel({ countryName, onClose }: CountryPanelProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end bg-black/50" onClick={onClose}>
+      <div
+        className="bg-white text-navy w-80 max-w-full p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          className="mb-4 text-right w-full text-sm text-orange font-semibold"
+          onClick={onClose}
+        >
+          Fermer
+        </button>
+        <h3 className="text-xl font-bold mb-2">{countryName}</h3>
+        <p className="text-sm">
+          {/* Texte d'inspiration à personnaliser plus tard */}
+          Cette section contiendra mes inspirations pour ce pays.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/blabla/src/app/page.tsx
+++ b/blabla/src/app/page.tsx
@@ -1,9 +1,33 @@
+import { useState } from "react";
 import WorldMap from "@/components/WorldMap";
+import CountryPanel from "@/components/CountryPanel";
 
 export default function Home() {
+  const [selectedCountry, setSelectedCountry] = useState<string | null>(null);
+
+  const projects = [
+    {
+      title: "Projet A",
+      description: "Une courte description du projet A.",
+      link: "https://example.com/projet-a",
+    },
+    {
+      title: "Projet B",
+      description: "Une courte description du projet B.",
+      link: "https://example.com/projet-b",
+    },
+    {
+      title: "Projet C",
+      description: "Une courte description du projet C.",
+      link: "https://example.com/projet-c",
+    },
+  ];
+
   const handleCountryClick = (country: any) => {
-    alert(`Inspiration pour ${country.NAME}`);
+    setSelectedCountry(country.NAME);
   };
+
+  const closePanel = () => setSelectedCountry(null);
 
   return (
     <main className="p-6 text-center">
@@ -16,11 +40,24 @@ export default function Home() {
         INSPIRATIONS DU MONDE
       </h2>
       <WorldMap onCountryClick={handleCountryClick} />
+      {selectedCountry && (
+        <CountryPanel countryName={selectedCountry} onClose={closePanel} />
+      )}
 
       <h2 className="text-2xl font-semibold mt-16 mb-4 text-blue-900">
         MES PROJETS
       </h2>
-      {/* On ajoutera ici le tableau stylisé plus tard */}
+      <div className="mx-auto max-w-4xl grid gap-4">
+        {projects.map((p) => (
+          <div key={p.title} className="border border-navy/20 p-4 rounded-lg shadow-sm text-left bg-white">
+            <h3 className="text-xl font-semibold text-navy mb-1">{p.title}</h3>
+            <p className="text-sm mb-2 text-navy/80">{p.description}</p>
+            <a href={p.link} className="text-orange font-medium" target="_blank" rel="noopener noreferrer">
+              Voir le projet
+            </a>
+          </div>
+        ))}
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add instructions in README
- add country panel for inspirations
- make world map open the panel when clicking a country
- display a simple project list
- add react-simple-maps dependency

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860547208a08329920754009bcb011e