### PR TITLE
Add country inspiration data file and use it

### DIFF
--- a/blabla/src/app/components/CountryPanel.tsx
+++ b/blabla/src/app/components/CountryPanel.tsx
@@ -1,11 +1,17 @@
 "use client";
 
+import {
+  countryInspirations,
+  defaultInspiration,
+} from "@/data/countryInspirations";
 interface CountryPanelProps {
   countryName: string;
   onClose: () => void;
 }
 
 export default function CountryPanel({ countryName, onClose }: CountryPanelProps) {
+  const inspirationText =
+    countryInspirations[countryName] ?? defaultInspiration;
   return (
     <div className="fixed inset-0 z-50 flex justify-end bg-black/50" onClick={onClose}>
       <div
@@ -19,10 +25,7 @@ export default function CountryPanel({ countryName, onClose }: CountryPanelProps
           Fermer
         </button>
         <h3 className="text-xl font-bold mb-2">{countryName}</h3>
-        <p className="text-sm">
-          {/* Texte d'inspiration à personnaliser plus tard */}
-          Cette section contiendra mes inspirations pour ce pays.
-        </p>
+        <p className="text-sm">{inspirationText}</p>
       </div>
     </div>
   );

--- a/blabla/src/data/countryInspirations.ts
+++ b/blabla/src/data/countryInspirations.ts
@@ -1,0 +1,9 @@
+export const countryInspirations: Record<string, string> = {
+  "France": "Berceau de mon imagination, source inépuisable d'art et de gastronomie.",
+  "Japan": "La beauté de ses traditions et de sa technologie m'inspire chaque jour.",
+  "Brazil": "Sa joie de vivre et ses couleurs réveillent ma créativité.",
+  "United States of America": "L'énergie de ses grandes villes m'encourage à voir grand."
+};
+
+export const defaultInspiration =
+  "Je n'ai pas encore écrit d'inspiration pour ce pays.";


### PR DESCRIPTION
## Summary
- map countries to short inspiration texts
- use the inspiration text in `CountryPanel`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68605c18955483298cb4fa1840e7701c